### PR TITLE
 Add Alloy formal models for all header types

### DIFF
--- a/alloy/bool_type.als
+++ b/alloy/bool_type.als
@@ -1,0 +1,25 @@
+module bool_type
+
+open common
+
+-- Bool: header byte 0x02 (false) or 0x03 (true).
+-- Bits 7–2 are Zero; b1 = One is the type discriminator; b0 carries the value.
+sig BoolHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero
+    b3 = Zero
+    b2 = Zero
+    b1 = One
+    -- b0: Zero = false, One = true (free)
+}
+
+-- Two Bool headers with different b0 values have different bit patterns.
+assert BoolPatternsDistinct {
+    all h1, h2: BoolHeader | h1.b0 != h2.b0 implies not samePattern[h1, h2]
+}
+
+run showFalse { some h: BoolHeader | h.b0 = Zero } for 2 expect 1
+run showTrue { some h: BoolHeader | h.b0 = One } for 2 expect 1
+check BoolPatternsDistinct for 4 expect 0

--- a/alloy/bytes_type.als
+++ b/alloy/bytes_type.als
@@ -1,0 +1,27 @@
+module bytes_type
+
+open common
+
+-- Bytes header: 0x04–0x07 (0b000001XX).
+-- Bits 7–3 = Zero (type prefix), b2 = One (bytes type flag),
+-- bits 1–0 encode the length-field width exponent e ∈ {0..3},
+-- so the <INTEGER> length field is 2^e bytes wide (1, 2, 4, or 8 bytes).
+sig BytesHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero
+    b3 = Zero
+    b2 = One
+    -- b1, b0 are free: they encode the length-field width exponent (0..3)
+}
+
+run showBytes { some BytesHeader } for 2 expect 1
+
+-- The type prefix bits are fixed.
+assert BytesTypeBitsFixed {
+    all h: BytesHeader |
+        h.b7=Zero and h.b6=Zero and h.b5=Zero and
+        h.b4=Zero and h.b3=Zero and h.b2=One
+}
+check BytesTypeBitsFixed for 4 expect 0

--- a/alloy/common.als
+++ b/alloy/common.als
@@ -1,0 +1,23 @@
+module common
+
+-- A single bit.
+abstract sig Bit {}
+one sig Zero, One extends Bit {}
+
+-- An 8-bit wire-format header byte.
+-- Each field corresponds to one bit position (b7 = MSB, b0 = LSB).
+sig Header {
+    b7, b6, b5, b4, b3, b2, b1, b0: one Bit
+}
+
+-- True when two headers carry the same bit pattern.
+pred samePattern[h1, h2: Header] {
+    h1.b7 = h2.b7
+    h1.b6 = h2.b6
+    h1.b5 = h2.b5
+    h1.b4 = h2.b4
+    h1.b3 = h2.b3
+    h1.b2 = h2.b2
+    h1.b1 = h2.b1
+    h1.b0 = h2.b0
+}

--- a/alloy/float_type.als
+++ b/alloy/float_type.als
@@ -1,0 +1,79 @@
+module float_type
+
+open common
+
+-- Float header: 0x08–0x0F (0b00001XXX).
+-- Bits 7–4 = Zero (type prefix), b3 = One (float type flag),
+-- bits 2–0 encode (byteWidth − 1) in {0..7}, giving byte widths 1–8.
+sig FloatHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero
+    b3 = One
+    -- b2, b1, b0 are free: they encode byteWidth−1 (0..7)
+}
+
+run showFloat { some FloatHeader } for 2 expect 1
+
+-- The type prefix bits are fixed.
+assert FloatTypeBitsFixed {
+    all h: FloatHeader | h.b7=Zero and h.b6=Zero and h.b5=Zero and h.b4=Zero and h.b3=One
+}
+check FloatTypeBitsFixed for 4 expect 0
+
+-- -------------------------------------------------------------------------
+-- Float bit-field layout model
+--
+-- For each byte width w ∈ {1..8}, the IEEE-754-generalised layout is:
+-- sign=1 exponent=E significand=S where 1 + E + S = w × 8
+-- -------------------------------------------------------------------------
+
+abstract sig FloatLayout {
+    signBits: one Int,
+    exponentBits: one Int,
+    significandBits: one Int,
+    totalBits: one Int
+}
+
+one sig FL8 extends FloatLayout {} { signBits=1 and exponentBits=4 and significandBits=3 and totalBits=8 }
+one sig FL16 extends FloatLayout {} { signBits=1 and exponentBits=5 and significandBits=10 and totalBits=16 }
+one sig FL24 extends FloatLayout {} { signBits=1 and exponentBits=7 and significandBits=16 and totalBits=24 }
+one sig FL32 extends FloatLayout {} { signBits=1 and exponentBits=8 and significandBits=23 and totalBits=32 }
+one sig FL40 extends FloatLayout {} { signBits=1 and exponentBits=8 and significandBits=31 and totalBits=40 }
+one sig FL48 extends FloatLayout {} { signBits=1 and exponentBits=9 and significandBits=38 and totalBits=48 }
+one sig FL56 extends FloatLayout {} { signBits=1 and exponentBits=10 and significandBits=45 and totalBits=56 }
+one sig FL64 extends FloatLayout {} { signBits=1 and exponentBits=11 and significandBits=52 and totalBits=64 }
+
+-- sign + exponent + significand = totalBits (the partition is exact).
+assert FloatLayoutPartitionsExactly {
+    all f: FloatLayout |
+        f.signBits.plus[f.exponentBits].plus[f.significandBits] = f.totalBits
+}
+
+-- Sign field is always exactly 1 bit.
+assert FloatSignIsOneBit {
+    all f: FloatLayout | f.signBits = 1
+}
+
+-- Total width is a multiple of 8 and lies within [8, 64].
+assert FloatTotalBitsIsWholeByte {
+    all f: FloatLayout |
+        f.totalBits >= 8 and f.totalBits <= 64 and f.totalBits.rem[8] = 0
+}
+
+-- Exponent grows monotonically with width (except 32-bit and 40-bit share exp=8).
+assert FloatExponentNonDecreasing {
+    FL8.exponentBits <= FL16.exponentBits and
+    FL16.exponentBits <= FL24.exponentBits and
+    FL24.exponentBits <= FL32.exponentBits and
+    FL32.exponentBits <= FL40.exponentBits and
+    FL40.exponentBits <= FL48.exponentBits and
+    FL48.exponentBits <= FL56.exponentBits and
+    FL56.exponentBits <= FL64.exponentBits
+}
+
+check FloatLayoutPartitionsExactly for 0 but 8 int expect 0
+check FloatSignIsOneBit for 0 but 8 int expect 0
+check FloatTotalBitsIsWholeByte for 0 but 8 int expect 0
+check FloatExponentNonDecreasing for 0 but 8 int expect 0

--- a/alloy/integer_type.als
+++ b/alloy/integer_type.als
@@ -1,0 +1,84 @@
+module integer_type
+
+open common
+
+-- Compact unsigned integer: 0xC0–0xDF (0b110XXXXX).
+-- b7 = One (integer type), b6 = One (compact variant), b5 = Zero (unsigned),
+-- bits 4–0 encode the packed unsigned value in {0..31}.
+sig CompactUnsignedIntHeader extends Header {} {
+    b7 = One
+    b6 = One
+    b5 = Zero
+    -- b4..b0 encode the packed unsigned value — free
+}
+
+-- Compact signed integer: 0xE0–0xFF (0b111XXXXX).
+-- b7 = One, b6 = One (compact), b5 = One (signed),
+-- bits 4–0 encode the zig-zag-encoded value in {0..31}.
+sig CompactSignedIntHeader extends Header {} {
+    b7 = One
+    b6 = One
+    b5 = One
+    -- b4..b0 encode the zig-zag packed value — free
+}
+
+-- Extended unsigned integer: 0x80–0x87 (0b10000XXX).
+-- b7 = One, b6 = Zero (extended), b5 = Zero (unsigned),
+-- b4 = Zero and b3 = Zero (reserved, must be Zero),
+-- bits 2–0 encode (byteWidth − 1) in {0..7}.
+sig ExtendedUnsignedIntHeader extends Header {} {
+    b7 = One
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero -- reserved
+    b3 = Zero -- reserved
+    -- b2..b0 encode (byteWidth − 1) — free
+}
+
+-- Extended signed integer: 0xA0–0xA7 (0b10100XXX).
+-- b7 = One, b6 = Zero (extended), b5 = One (signed),
+-- b4 = Zero and b3 = Zero (reserved, must be Zero),
+-- bits 2–0 encode (byteWidth − 1) in {0..7}.
+sig ExtendedSignedIntHeader extends Header {} {
+    b7 = One
+    b6 = Zero
+    b5 = One
+    b4 = Zero -- reserved
+    b3 = Zero -- reserved
+    -- b2..b0 encode (byteWidth − 1) — free
+}
+
+run showCompactUnsigned { some CompactUnsignedIntHeader } for 2 expect 1
+run showCompactSigned { some CompactSignedIntHeader } for 2 expect 1
+run showExtendedUnsigned { some ExtendedUnsignedIntHeader } for 2 expect 1
+run showExtendedSigned { some ExtendedSignedIntHeader } for 2 expect 1
+
+-- Reserved bits on extended headers are always Zero.
+assert ExtendedUnsignedIntReservedZero {
+    all h: ExtendedUnsignedIntHeader | h.b4 = Zero and h.b3 = Zero
+}
+assert ExtendedSignedIntReservedZero {
+    all h: ExtendedSignedIntHeader | h.b4 = Zero and h.b3 = Zero
+}
+
+-- Compact and extended share b7=One but differ in b6 (One vs Zero).
+assert CompactExtendedIntDisjoint {
+    no h1: CompactUnsignedIntHeader, h2: ExtendedUnsignedIntHeader | samePattern[h1, h2]
+    no h1: CompactSignedIntHeader, h2: ExtendedSignedIntHeader | samePattern[h1, h2]
+}
+
+-- Signed and unsigned compact variants differ in b5.
+assert CompactSignedUnsignedDisjoint {
+    no h1: CompactUnsignedIntHeader, h2: CompactSignedIntHeader | samePattern[h1, h2]
+}
+
+-- Signed and unsigned extended variants differ in b5.
+assert ExtendedSignedUnsignedDisjoint {
+    no h1: ExtendedUnsignedIntHeader, h2: ExtendedSignedIntHeader | samePattern[h1, h2]
+}
+
+check ExtendedUnsignedIntReservedZero for 4 expect 0
+check ExtendedSignedIntReservedZero for 4 expect 0
+check CompactExtendedIntDisjoint for 4 expect 0
+check CompactSignedUnsignedDisjoint for 4 expect 0
+check ExtendedSignedUnsignedDisjoint for 4 expect 0

--- a/alloy/map_type.als
+++ b/alloy/map_type.als
@@ -1,0 +1,38 @@
+module map_type
+
+open common
+
+-- Compact map header: 0x18–0x1F (0b00011XXX).
+-- Bits 7–5 = Zero (type prefix), b4 = One (map type),
+-- b3 = One (compact variant), bits 2–0 = entry count in {0..7}.
+sig CompactMapHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = One
+    b3 = One
+    -- b2..b0 encode entry count (0..7) — free
+}
+
+-- Extended map header: 0x10–0x17 (0b00010XXX).
+-- Bits 7–5 = Zero, b4 = One (map type), b3 = Zero (extended),
+-- bits 2–0 encode (countFieldWidth − 1) in {0..7}.
+-- No reserved bits: all lower 3 bits carry the width encoding.
+sig ExtendedMapHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = One
+    b3 = Zero
+    -- b2..b0 encode (countFieldWidth − 1) — free
+}
+
+run showCompactMap { some CompactMapHeader } for 2 expect 1
+run showExtendedMap { some ExtendedMapHeader } for 2 expect 1
+
+-- Compact and extended differ in b3 (One vs Zero).
+assert CompactExtendedMapDisjoint {
+    no h1: CompactMapHeader, h2: ExtendedMapHeader | samePattern[h1, h2]
+}
+
+check CompactExtendedMapDisjoint for 4 expect 0

--- a/alloy/null_type.als
+++ b/alloy/null_type.als
@@ -1,0 +1,24 @@
+module null_type
+
+open common
+
+-- Null: header byte 0x00 (0b00000000).
+-- All eight bits are fixed to Zero; no variant fields.
+sig NullHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero
+    b3 = Zero
+    b2 = Zero
+    b1 = Zero
+    b0 = Zero
+}
+
+-- All Null headers share the same bit pattern.
+assert NullPatternIsUniform {
+    all h1, h2: NullHeader | samePattern[h1, h2]
+}
+
+run showNull { some NullHeader } for 2 expect 1
+check NullPatternIsUniform for 4 expect 0

--- a/alloy/sequence_type.als
+++ b/alloy/sequence_type.als
@@ -1,0 +1,43 @@
+module sequence_type
+
+open common
+
+-- Compact sequence header: 0x30–0x3F (0b0011XXXX).
+-- Bits 7–6 = Zero (type prefix), b5 = One (sequence type),
+-- b4 = One (compact variant), bits 3–0 = element count in {0..15}.
+sig CompactSeqHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = One
+    b4 = One
+    -- b3..b0 encode element count (0..15) — free
+}
+
+-- Extended sequence header: 0x20–0x27 (0b00100XXX).
+-- Bits 7–6 = Zero, b5 = One (sequence type), b4 = Zero (extended),
+-- b3 = Zero (reserved, must be Zero),
+-- bits 2–0 encode (countFieldWidth − 1) in {0..7}.
+sig ExtendedSeqHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = One
+    b4 = Zero
+    b3 = Zero -- reserved
+    -- b2..b0 encode (countFieldWidth − 1) — free
+}
+
+run showCompactSeq { some CompactSeqHeader } for 2 expect 1
+run showExtendedSeq { some ExtendedSeqHeader } for 2 expect 1
+
+-- Reserved bit on extended header is always Zero.
+assert ExtendedSeqReservedZero {
+    all h: ExtendedSeqHeader | h.b3 = Zero
+}
+
+-- Compact and extended differ in b4 (One vs Zero).
+assert CompactExtendedSeqDisjoint {
+    no h1: CompactSeqHeader, h2: ExtendedSeqHeader | samePattern[h1, h2]
+}
+
+check ExtendedSeqReservedZero for 4 expect 0
+check CompactExtendedSeqDisjoint for 4 expect 0

--- a/alloy/string_type.als
+++ b/alloy/string_type.als
@@ -1,0 +1,42 @@
+module string_type
+
+open common
+
+-- Compact string header: 0x60–0x7F (0b011XXXXX).
+-- b7 = Zero, b6 = One (string type), b5 = One (compact variant set),
+-- bits 4–0 encode the string's byte-length in {0..31}.
+sig CompactStringHeader extends Header {} {
+    b7 = Zero
+    b6 = One
+    b5 = One
+    -- b4..b0 encode byte-length (0..31) — free
+}
+
+-- Extended string header: 0x40–0x47 (0b01000XXX).
+-- b7 = Zero, b6 = One (string type), b5 = Zero (compact variant not set),
+-- b4 = Zero and b3 = Zero (reserved, must be Zero),
+-- bits 2–0 encode (lengthFieldWidth − 1) in {0..7}.
+sig ExtendedStringHeader extends Header {} {
+    b7 = Zero
+    b6 = One
+    b5 = Zero
+    b4 = Zero -- reserved
+    b3 = Zero -- reserved
+    -- b2..b0 encode (lengthFieldWidth − 1) — free
+}
+
+run showCompactString { some CompactStringHeader } for 2 expect 1
+run showExtendedString { some ExtendedStringHeader } for 2 expect 1
+
+-- Reserved bits on extended headers are always Zero.
+assert ExtendedStringReservedZero {
+    all h: ExtendedStringHeader | h.b4 = Zero and h.b3 = Zero
+}
+
+-- Compact and extended headers cannot share a bit pattern (b5 differs).
+assert CompactExtendedStringDisjoint {
+    no h1: CompactStringHeader, h2: ExtendedStringHeader | samePattern[h1, h2]
+}
+
+check ExtendedStringReservedZero for 4 expect 0
+check CompactExtendedStringDisjoint for 4 expect 0

--- a/alloy/unit_type.als
+++ b/alloy/unit_type.als
@@ -1,0 +1,24 @@
+module unit_type
+
+open common
+
+-- Unit: header byte 0x01 (0b00000001).
+-- b0 = One is the sole distinguishing bit; all others are Zero.
+sig UnitHeader extends Header {} {
+    b7 = Zero
+    b6 = Zero
+    b5 = Zero
+    b4 = Zero
+    b3 = Zero
+    b2 = Zero
+    b1 = Zero
+    b0 = One
+}
+
+-- All Unit headers share the same bit pattern.
+assert UnitPatternIsUniform {
+    all h1, h2: UnitHeader | samePattern[h1, h2]
+}
+
+run showUnit { some UnitHeader } for 2 expect 1
+check UnitPatternIsUniform for 4 expect 0

--- a/alloy/value.als
+++ b/alloy/value.als
@@ -1,0 +1,214 @@
+module value
+
+open common
+open null_type
+open unit_type
+open bool_type
+open float_type
+open bytes_type
+open string_type
+open integer_type
+open sequence_type
+open map_type
+
+-- =========================================================================
+-- Value type hierarchy
+-- =========================================================================
+-- Each Value variant holds one header that encodes its wire representation.
+-- Sequence and Map reference the abstract Value sig for their elements,
+-- giving the flat recursive structure bounded by Alloy's scope.
+
+abstract sig Value {}
+
+sig NullValue extends Value { header: one NullHeader }
+sig UnitValue extends Value { header: one UnitHeader }
+sig BoolValue extends Value { header: one BoolHeader }
+sig FloatValue extends Value { header: one FloatHeader }
+sig BytesValue extends Value { header: one BytesHeader }
+
+-- String and Integer each have two wire variants; both are absorbed into
+-- a single semantic Value kind.
+sig StringValue extends Value { header: one (CompactStringHeader + ExtendedStringHeader) }
+sig IntValue extends Value { header: one (CompactUnsignedIntHeader + CompactSignedIntHeader
+                                            + ExtendedUnsignedIntHeader + ExtendedSignedIntHeader) }
+
+-- Sequence: an ordered collection of arbitrary Values.
+sig SeqValue extends Value {
+    seqHeader: one (CompactSeqHeader + ExtendedSeqHeader),
+    elements: set Value -- element order is abstracted away
+}
+
+-- Map: a key-value collection where both keys and values are arbitrary Values.
+sig MapValue extends Value {
+    mapHeader: one (CompactMapHeader + ExtendedMapHeader),
+    entries: Value -> lone Value -- each key maps to at most one value
+}
+
+-- =========================================================================
+-- Type-tag enumeration
+-- =========================================================================
+-- One atom per valid wire type, plus TInvalid for the header bytes that
+-- carry reserved-bit violations.
+
+abstract sig TypeTag {}
+one sig TNull, TUnit, TBool, TBytes, TFloat,
+        TMapExtended, TMapCompact,
+        TSeqExtended, TSeqCompact,
+        TStringExtended, TStringCompact,
+        TIntExtUnsigned, TIntExtSigned,
+        TIntCmpUnsigned, TIntCmpSigned,
+        TInvalid
+        extends TypeTag {}
+
+-- =========================================================================
+-- Complete decode trie
+-- =========================================================================
+-- typeOf implements the decoder's type-dispatch logic as a total function
+-- over all 256 possible header byte patterns.
+-- Reading from bit 7 (MSB) down to bit 0, each branch follows the actual
+-- implementation constants in lilliput-core/src/header/*.rs.
+
+fun typeOf[h: Header]: TypeTag {
+    (h.b7 = One) =>
+        (h.b6 = One) =>
+            (h.b5 = One) => TIntCmpSigned
+            else TIntCmpUnsigned
+        else
+            -- Extended integer: reserved bits b4 and b3 must be Zero
+            (h.b4 = One or h.b3 = One) => TInvalid
+            else
+                (h.b5 = One) => TIntExtSigned
+                else TIntExtUnsigned
+    else
+    (h.b6 = One) =>
+        (h.b5 = One) => TStringCompact
+        else
+            -- Extended string: reserved bits b4 and b3 must be Zero
+            (h.b4 = One or h.b3 = One) => TInvalid
+            else TStringExtended
+    else
+    (h.b5 = One) =>
+        (h.b4 = One) => TSeqCompact
+        else
+            -- Extended sequence: reserved bit b3 must be Zero
+            (h.b3 = One) => TInvalid
+            else TSeqExtended
+    else
+    (h.b4 = One) =>
+        (h.b3 = One) => TMapCompact
+        else TMapExtended
+    else
+    (h.b3 = One) => TFloat
+    else
+    (h.b2 = One) => TBytes
+    else
+    (h.b1 = One) => TBool
+    else
+    (h.b0 = One) => TUnit
+    else TNull
+}
+
+-- =========================================================================
+-- Soundness assertions
+-- =========================================================================
+
+-- (1) Disjoint opcodes:
+-- Every header byte maps to exactly one TypeTag.
+-- typeOf is a total function by construction, so the singleton check
+-- verifies no branch returns an empty or multi-element set.
+assert DisjointOpcodes {
+    all h: Header | one typeOf[h]
+}
+
+-- (2) Consistency: typed-sig constraints agree with the decode trie.
+-- If a header atom belongs to a typed sig, typeOf must return the
+-- corresponding tag — verifying that the sig bit-constraints and the
+-- trie are mutually consistent.
+assert TypeOfConsistentWithSigs {
+    all h: NullHeader | typeOf[h] = TNull
+    all h: UnitHeader | typeOf[h] = TUnit
+    all h: BoolHeader | typeOf[h] = TBool
+    all h: BytesHeader | typeOf[h] = TBytes
+    all h: FloatHeader | typeOf[h] = TFloat
+    all h: CompactMapHeader | typeOf[h] = TMapCompact
+    all h: ExtendedMapHeader | typeOf[h] = TMapExtended
+    all h: CompactSeqHeader | typeOf[h] = TSeqCompact
+    all h: ExtendedSeqHeader | typeOf[h] = TSeqExtended
+    all h: CompactStringHeader | typeOf[h] = TStringCompact
+    all h: ExtendedStringHeader | typeOf[h] = TStringExtended
+    all h: CompactUnsignedIntHeader | typeOf[h] = TIntCmpUnsigned
+    all h: CompactSignedIntHeader | typeOf[h] = TIntCmpSigned
+    all h: ExtendedUnsignedIntHeader | typeOf[h] = TIntExtUnsigned
+    all h: ExtendedSignedIntHeader | typeOf[h] = TIntExtSigned
+}
+
+-- (3) Reserved-byte invalidity:
+-- No atom belonging to any typed sig is classified as TInvalid.
+-- This confirms no valid header pattern accidentally lands in the
+-- "reserved bits set" zones.
+assert NoTypedHeaderIsInvalid {
+    no h: Header |
+        typeOf[h] = TInvalid and (
+            h in NullHeader or h in UnitHeader or h in BoolHeader or
+            h in BytesHeader or h in FloatHeader or
+            h in CompactMapHeader or h in ExtendedMapHeader or
+            h in CompactSeqHeader or h in ExtendedSeqHeader or
+            h in CompactStringHeader or h in ExtendedStringHeader or
+            h in CompactUnsignedIntHeader or h in CompactSignedIntHeader or
+            h in ExtendedUnsignedIntHeader or h in ExtendedSignedIntHeader
+        )
+}
+
+-- (4) Coverage: every header byte is either a valid type or explicitly invalid.
+-- (There are no "unknown" byte patterns — TInvalid absorbs all gaps.)
+assert FullCoverage {
+    all h: Header | typeOf[h] != none
+}
+
+-- (5) Unique decoding (no lookahead):
+-- Streaming decoders must identify the wire type from the header byte
+-- alone. This asserts that typeOf is determined solely by the byte's
+-- bit pattern — two headers with identical bits cannot disagree about
+-- their classification, so context-free single-byte dispatch is sound.
+assert UniqueDecoding {
+    all h1, h2: Header | samePattern[h1, h2] => typeOf[h1] = typeOf[h2]
+}
+
+-- (6) Prefix-free dispatch (single-byte partition):
+-- The typed sigs are pairwise disjoint and, together with the TInvalid
+-- byte patterns, partition the entire 256-byte header space. No header
+-- can satisfy two distinct typed-sig constraints simultaneously, which
+-- is precisely what allows the decoder to commit to a wire type after
+-- reading exactly one byte. Stated bidirectionally: a header belongs
+-- to a typed sig iff typeOf returns the corresponding tag.
+assert PrefixFreeDispatch {
+    all h: Header | h in NullHeader <=> typeOf[h] = TNull
+    all h: Header | h in UnitHeader <=> typeOf[h] = TUnit
+    all h: Header | h in BoolHeader <=> typeOf[h] = TBool
+    all h: Header | h in BytesHeader <=> typeOf[h] = TBytes
+    all h: Header | h in FloatHeader <=> typeOf[h] = TFloat
+    all h: Header | h in CompactMapHeader <=> typeOf[h] = TMapCompact
+    all h: Header | h in ExtendedMapHeader <=> typeOf[h] = TMapExtended
+    all h: Header | h in CompactSeqHeader <=> typeOf[h] = TSeqCompact
+    all h: Header | h in ExtendedSeqHeader <=> typeOf[h] = TSeqExtended
+    all h: Header | h in CompactStringHeader <=> typeOf[h] = TStringCompact
+    all h: Header | h in ExtendedStringHeader <=> typeOf[h] = TStringExtended
+    all h: Header | h in CompactUnsignedIntHeader <=> typeOf[h] = TIntCmpUnsigned
+    all h: Header | h in CompactSignedIntHeader <=> typeOf[h] = TIntCmpSigned
+    all h: Header | h in ExtendedUnsignedIntHeader <=> typeOf[h] = TIntExtUnsigned
+    all h: Header | h in ExtendedSignedIntHeader <=> typeOf[h] = TIntExtSigned
+}
+
+-- =========================================================================
+-- Run / check commands
+-- =========================================================================
+
+run showValue { some SeqValue and some MapValue } for 4 expect 1
+run showNestedSeq { some s: SeqValue | some s.elements } for 4 expect 1
+
+check DisjointOpcodes for 4 expect 0
+check TypeOfConsistentWithSigs for 4 expect 0
+check NoTypedHeaderIsInvalid for 4 expect 0
+check FullCoverage for 4 expect 0
+check UniqueDecoding for 4 expect 0
+check PrefixFreeDispatch for 4 expect 0


### PR DESCRIPTION
Properties that are verified:

The four assertions in [value.als:119-166](alloy/value.als#L119), together with the per-type assertions, jointly verify one property:

> **Type-tag dispatch is well-defined and consistent across the entire 256-byte header space.**

Specifically:

1. **`DisjointOpcodes`: every header maps to exactly one tag.

    (Trivially true given that `typeOf` is a total function, but it's a sanity assertion that none of the trie branches accidentally returns `none`.)

2. **`TypeOfConsistentWithSigs`: or each typed sig, every member is classified by the trie under the corresponding tag.

3. **`NoTypedHeaderIsInvalid`:** no member of a valid sig accidentally lands in the reserved-bit `TInvalid` zone.

4. **`FullCoverage`:** every header byte is classified.

    (Trivial by construction of `typeOf`, but a useful guard against accidental incompleteness.)

7. **Per-type disjointness assertions** (e.g. `CompactExtendedIntDisjoint`, `CompactSignedUnsignedDisjoint`, `CompactExtendedSeqDisjoint`, `CompactExtendedMapDisjoint`, `CompactExtendedStringDisjoint`): the variants of each type don't share bit patterns.

    (These are tautological given the sig constraints, but again provide defence-in-depth.)

8. **Reserved-bit assertions** (e.g. `ExtendedUnsignedIntReservedZero`, `ExtendedStringReservedZero`, `ExtendedSeqReservedZero`): every reserved bit must be zero.

    (These are tautological given the sig constraints, but they document and pin down the protocol's "must be zero" requirements.)

10. **`FloatLayout*` assertions:** the eight declared float layouts internally satisfy `signBits + exponentBits + significandBits = totalBits`, sign is always 1 bit, total is a whole number of bytes in [8, 64], and exponents are non-decreasing with width.